### PR TITLE
Displaying linked documents in a document's template

### DIFF
--- a/detail.html
+++ b/detail.html
@@ -25,6 +25,24 @@
             </script>
         </article>
 
+        <aside>
+            <script type="text/template">
+                <% if(doc.linkedDocuments.length > 0) { %>
+                    <hr>
+                    <h2>Linked documents:</h2>
+                    <ul>
+                        <% for(var i=0; i<doc.linkedDocuments.length; i++) { %>
+                            <li>
+                                <a href="detail.html?id=<%= doc.linkedDocuments[i].id %>&slug=<%= doc.linkedDocuments[i].slug %>">
+                                    <%= doc.linkedDocuments[i].slug %>
+                                </a>
+                            </li>
+                        <% } %>
+                    </ul>
+                <% } %>
+            </script>
+        </aside>
+
         <footer>
             <script type="text/template">
                 <% if(!ctx.oauth().hasPrivilegedAccess) { %>
@@ -66,7 +84,7 @@
                         }
 
                         // Feed the templates
-                        $('header, article, footer').render({
+                        $('header, article, aside, footer').render({
                             doc: doc,
                             ctx: ctx
                         });


### PR DESCRIPTION
Making good use of the brand new linked documents exposed in the API, and listing them in the "document" template.

**Careful: do not merge this as long as the linked documents feature is not live in all repository APIs!**
