### PR TITLE
updated Helper.getApiHome to use accessToken if supplied

### DIFF
--- a/js/prismic-configuration.js
+++ b/js/prismic-configuration.js
@@ -2,6 +2,7 @@ var Configuration = {
 
   // -- API endpoint
   apiEndpoint: 'https://lesbonneschoses.prismic.io/api',
+  //accessToken: '',
 
   // -- OAuth
   //clientId: 'U9YR2TQAADQAcZsA',

--- a/js/prismic-helpers.js
+++ b/js/prismic-helpers.js
@@ -19,7 +19,7 @@
     global.Helpers = {
 
         getApiHome: function(callback) {
-            Prismic.Api(Configuration.apiEndpoint, callback);
+            Prismic.Api(Configuration.apiEndpoint, callback, Configuration.accessToken);
         },
 
         buildContext: function(ref, callback) {


### PR DESCRIPTION
Makes it easier to get started with access tokens for your repo. 

The example configuration in the README has the `accessToken` commented out, but just adding one in didn't work: the `getApiHome` helper wasn't using it.
